### PR TITLE
Adding "canonical" meta tag for search bots

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -6,5 +6,5 @@
     <link href="{{ page.root }}/css/journal.min.css" rel="stylesheet">
     <link href="{{ page.root }}/css/revel.css" rel="stylesheet">
     <link href="http://fonts.googleapis.com/css?family=Open+Sans:400italic,400,700" rel="stylesheet" type="text/css">
-    <!-- Adding "canonicak" meta tag, as suggested on https://github.com/revel/revel/issues/699. -->
+    <!-- Adding "canonical" meta tag, as suggested on https://github.com/revel/revel/issues/699. -->
     <link rel="canonical" href="https://revel.github.io{{ page.url }}" />

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -5,4 +5,6 @@
     <link href="{{ page.root }}/css/bootstrap.min.css" rel="stylesheet">
     <link href="{{ page.root }}/css/journal.min.css" rel="stylesheet">
     <link href="{{ page.root }}/css/revel.css" rel="stylesheet">
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:400italic,400,700" rel="stylesheet" type="text/css">
+    <link href="http://fonts.googleapis.com/css?family=Open+Sans:400italic,400,700" rel="stylesheet" type="text/css">
+    <!-- Adding "canonicak" meta tag, as suggested on https://github.com/revel/revel/issues/699. -->
+    <link rel="canonical" href="https://revel.github.io{{ page.url }}" />


### PR DESCRIPTION
This commit attempts to close [#699](https://github.com/revel/revel/issues/699)

The `confirm()` call in `./_includes/topnav.html` was left intact, hoping that this change would affect only search engines and would replace "http://robfig.github.io/" with "http://revel.github.io/" for the first results.
